### PR TITLE
007-nsatz-inequalities: more efficient algorithm

### DIFF
--- a/text/007-nsatz-inequalities.md
+++ b/text/007-nsatz-inequalities.md
@@ -19,7 +19,24 @@ allow it to handle inequalities, and, if possible, be complete on that domain.
 
 Suppose we have a solver, `nsatz`, for polynomial equalities over an integral
 domain `F`.  We can reduce the following problems to already solved problems,
-thus enhansing `nsatz`:
+thus enhansing `nsatz` in two ways:
+
+### Multiplying inequalitites
+
+* if we have one inequality `H : p ≠ q` in the context and our goal is `False`,
+  we can `apply H` and reduce to the case where we have no inequalities in the
+  context and our goal is an equality.
+* if we have no inequalities in the context and our goal is `False`, we can pose
+  the inequality `integral_domain_one_zero : 1 ≠ 0`
+* if we have two inequalities `p ≠ q` and `r ≠ s` in the context, we can combine
+  them into a single inequality `(p - q) * (r - s) ≠ 0`.  This transformation is
+  conservative (does not turn solvable goals into unsolvable ones).
+* if our goal is an inequality `p ≠ q`, we can introduce the hypothesis `p = q`
+  and reduce our goal to `False`
+* if we have one inequality `p ≠ q` in the context and our goal is of the form `p' = q'`,
+  we can reduce our goal to `(p - q) * (p' - q') = 0`.
+
+### Inverses in the field of quotients
 
 * if the goal is an inequality, `unfold not` and introduce the contradictory
   equality into the context, leaving `False` as the goal.
@@ -40,11 +57,16 @@ thus enhansing `nsatz`:
 
 ## Open Questions
 
+* Which Implementation to use. The first requires almost no new theory,
+  the second is speculated to be more efficient.
+    - In case of the second, it would probably be best if the Ltac didn't
+      actually need to translate all equalities in the context to the field
+      of quotients, perhaps we could make this step (and everything after it)
+      reflective. Since the reflective representation of a polynomial does
+      not indicate what ring it is over, "changing" rings could be a no-op
+      (but it would require a general proof that this is always sound).
 * Should we keep `nsatz` as-is, and make a new tactic that handles more goals, or
   should we upgrade `nsatz` to handle these goals, under the same name?
-* It would probably be best if the Ltac didn't actually need to translate
-  all equalities in the context to the field of quotients, perhaps we could
-  make this step (and everything after it) reflective.
 
 ## Changes
 * 2016-07-02, first draft

--- a/text/007-nsatz-inequalities.md
+++ b/text/007-nsatz-inequalities.md
@@ -9,10 +9,8 @@
 # Summary
 
 The `nsatz` tactic is a powerful hammer for dealing with systems of polynomial
-equations over an integral domain.  It is hypothetically complete, though in
-practice it [fails when information is duplicated in the
-context](https://coq.inria.fr/bugs/show_bug.cgi?id=4880).  However, it does not
-deal with inequalities at all, even though it is technically possible to do so.
+equations over an integral domain.  However, it does not deal with inequalities
+at all, even though it is technically possible to do so.
 
 This CEP proposes an extension to the current behavior of `nsatz` which would
 allow it to handle inequalities, and, if possible, be complete on that domain.
@@ -22,28 +20,32 @@ allow it to handle inequalities, and, if possible, be complete on that domain.
 Suppose we have a solver, `nsatz`, for polynomial equalities over an integral
 domain `F`.  We can reduce the following problems to already solved problems,
 thus enhansing `nsatz`:
-* if we have one inequality `H : p ≠ q` in the context and our goal is `False`,
-  we can `apply H` and reduce to the case where we have no inequalities in the
-  context and our goal is an equality.
-* if we have no inequalities in the context and our goal is `False`, we can pose
-  the inequality `integral_domain_one_zero : 1 ≠ 0`
-* if we have two inequalities `p ≠ q` and `r ≠ s` in the context, we can combine
-  them into a single inequality `(p - q) * (r - s) ≠ 0`.  This transformation is
-  conservative (does not turn solvable goals into unsolvable ones).
-* if our goal is an inequality `p ≠ q`, we can introduce the hypothesis `p = q`
-  and reduce our goal to `False`
-* if we have one inequality `p ≠ q` in the context and our goal is of the form `p' = q'`,
-  we can reduce our goal to `(p - q) * (p' - q') = 0`.
+
+* if the goal is an inequality, `unfold not` and introduce the contradictory
+  equality into the context, leaving `False` as the goal.
+* if the goal is `False`, apply `integral_domain_one_zero : 1 = 0 -> False`.
+* change from the integral domain to the corresponding "field of quotients",
+  making all elements invertible. The equalities in the original context still
+  hold because the integral domain is a subring of its field of quotients.
+  Similarly, `1 = 0` in the field of quotients implies `1 = 0` in the subring.
+  See <http://www.maths.lth.se/matematiklth/personal/ssilvest/AlgebraVT2011/Lecture03Silvestrov.pdf>
+  theorem 5 for more information. Example: the field of quotients of `Z` is
+  `Q`, best visualized here as the "mixed fractions".
+* for each inequality in the context, change `x <> y` into `x - y <> 0`
+* for each inequality in the context, change `x <> 0` into `x * ix = 1` using
+  use a lemma like `forall x : field_element, x <> 0 -> exists ix, x*ix = 1`.
+  This transformation is invertible, so it must capture all information about
+  inequalities, but the goal after this step is only in terms of equalities,
+  so solving it should be as complete as `nsatz` is.
 
 ## Open Questions
 
 * Should we keep `nsatz` as-is, and make a new tactic that handles more goals, or
   should we upgrade `nsatz` to handle these goals, under the same name?
-* In the case where we need decidable equality, what should we do?
-  - Should we add a typeclass?
-  - Should we leave it over as a side condition when `trivial; decide equality` fails?
-  - Should we provide an internal version that leaves it as a side-condition, and make
-    the user-facing version fail when it doesn't fully solve the goal?
+* It would probably be best if the Ltac didn't actually need to translate
+  all equalities in the context to the field of quotients, perhaps we could
+  make this step (and everything after it) reflective.
 
 ## Changes
 * 2016-07-02, first draft
+* 2016-08-18, more efficient algorithm using inverses in the field of quotients


### PR DESCRIPTION
- The idea for the optimization is from https://github.com/coq/coq/pull/242#issuecomment-231128236 by @thery
- https://coq.inria.fr/bugs/show_bug.cgi?id=4880 is marked resolved, so it is probably no longer relevant to the CEP
- I am not sure whether the section about decidable equality is still relevant -- I think it is not, but I am not confident, so please check before this is merged.

@JasonGross: the performance of this algorithm could be tested out on https://github.com/JasonGross/fiat-crypto/blob/wip-weierstrass/src/WeierstrassCurve/WeierstrassCurveTheorems.v without implementing the field-of-quotients conversion because file already assumes that the integral domain in question is also a field.