### PR TITLE
A versioned, independent, development model for the standard library

### DIFF
--- a/text/000-versioned-stdlib.md
+++ b/text/000-versioned-stdlib.md
@@ -1,0 +1,162 @@
+- Title: A versioned, independent, development model for the standard library
+
+- Drivers: @Zimmi48 (co-drivers could be @ejgallego @herbelin @mattam82 @amahboubi ...)
+
+- Status: very preliminary draft, RFC
+
+----
+
+# Summary
+
+Versioning the standard library independently from Coq itself
+is important for better compatibility, especially in a development
+model where new versions of Coq are quite frequent.
+
+For practical reasons, this is better done by moving the `theories/`
+files out of the main repository and into a specific coq/lib repository.
+
+This move will also be a perfect opportunity to make sure that users
+are encouraged to contribute to the improvement of the library,
+and possibly to find additional maintainers coming from the user community.
+
+# Motivation
+
+The main motivation is to address the compatibility concern expressed
+by lots of users, at the level of the library. Moving to an independent
+versioning scheme will allow users to upgrade Coq without changing their
+version of the library; and to upgrade their dependency on the library
+without changing their version of Coq.
+
+# Detailed design
+
+A new repository coq/lib is created which contains the current state of
+the `theories/` files (except those which are absolutely necessary for
+building Coq).
+
+The development of the library continues in this repository and respects
+semantic versioning.
+
+## Semantic versioning means:
+
+- major versions can introduce breaking changes: they can add and remove
+things, change definitions, change names of theorems;
+
+- minor versions are about non-breaking improvements: they can only add
+new definitions and theorems; adding a new theorem to a hint database is
+considered a minor change: if users' scripts are relying on the failure
+of an automatic tactic (except if this tactic implements a specific
+decision procedure), it is completely fragile and thus it is their problem;
+
+- patch level versions are about fixing bugs: bugs are deviations between
+specification and implementation in definitions and decision procedures;
+normally if enough theorems are proved about a definition, it will
+probably not be buggy and thus patch level versions should be quite rare.
+
+## Development practices
+
+There is one branch per released major version (the stable branches, which
+are named v1, v2, v3...) plus the master branch.
+
+Breaking changes are always done on the master branch only.
+
+Non-breaking changes are always done on the latest stable branch, then
+merged into the master branch.
+
+All the supported versions of the library (the development version, the
+stable version and possibly a few legacy versions, i.e. older stable
+versions) are checked to compile with all the supported versions of Coq
+(thanks to automatic testing jobs).
+
+## Distribution
+
+The latest stable version and possibly some legacy versions are directly
+included in the Coq packages which are distributed for Windows, MacOS and
+Linux distributions.
+
+All the other versions, including the development version, are accessible
+through OPAM packages, or by manually downloading and compiling the
+corresponding archives.
+
+## Call for contributors
+
+Once the split is done, it would be a good thing for the library to have
+its own webpage and motivated maintainers who spread the word that it is
+open to contributions from the Coq user community.
+
+It can be discussed later but maybe some library developers would like to
+integrate part of their work directly in the standard library.
+
+The models here could be the QED project and the archive of formal proofs
+of Isabelle (and contribution models of other provers, e.g. Mizar, ACL2...).
+
+# Drawbacks
+
+The main drawback is that the split makes it harder to continue compiling
+Coq and its library. We discuss the proposed solution here.
+
+Expect the `Init/` sub-directory, everything in `theories/` would be
+ignored by git. This can be achieved by adding to `.gitignore`:
+
+    theories/*
+    !theories/Init/
+
+Calling a special make target would look for a git repository at `theories/dev/`.
+If it exists, it would fetch and checkout the latest changes from the master
+branch at coq/lib, otherwise it would just clone coq/lib at this location.
+
+Then it would look for git worktrees at `theories/v*` for each supported
+version. It would create missing worktrees and would fetch and checkout
+the latest changes from the corresponding branches at coq/lib for existing
+ones.
+
+Then it would build all the libraries under `theories/`, including those
+it didn't cloned / checked out but which just happen to be there.
+
+The recommended way of developing the library would be to create a new
+worktree for each new branch you want to test in parallel. In particular,
+the automatically created worktrees shouldn't be used because they are
+there to track the current state of the library. In case this is not
+respected by the developer, we would have to make sure that the make error
+is crystal clear.
+
+# Alternatives
+
+## Alternative solutions to the compilation issue
+
+An alternative to be able to compile the library from the main repository would
+be to use git submodules. I strongly reject this option because, to me, git
+submodules are useful to pull external dependencies which you don't update
+often, not to keep two developments by the same team in sync (otherwise
+submodule updates are too frequent).
+
+## Alternative solutions to solve the compatibility issue
+
+The main alternative is the status quo, and being really careful not to
+break compatibility when doing changes, and to introduce compatibility
+aliases when they are needed.
+
+# Unresolved questions
+
+- How many versions to support? This will have to be decided depending on
+the user demand, and also on the capabilities of the maintainers. In
+particular, the forthcoming consortium could help in maintaining a larger
+number of legacy versions.
+
+- Splitting the library in several parts has been discussed quite a few
+times in the past. To me this question should be postponed until the new
+development model is well tested. Then this question can be asked again
+with more confidence (if it still seems to be relevant).
+
+- There might be technical problems doing the split. I don't have enough
+knowledge to gauge the difficulty of having Coq compile without most of
+its `theories/` files. Some plugins in particular might be very dependent
+on part of the standard library (e.g. nsatz). Can we keep them in the main
+repository at first? It would reduce the level of changes needed.
+
+# Perspectives
+
+If this new development model and versioning scheme is successful, it
+could then be adapted to some plugins such as Ltac, but also CoqIDE,
+the IDE protocols, and even the unification algorithm. But going too fast
+would be risky and the standard library is a relatively simple example to
+start with.

--- a/text/000-versioned-stdlib.md
+++ b/text/000-versioned-stdlib.md
@@ -30,10 +30,9 @@ without changing their version of Coq.
 # Detailed design
 
 A new repository coq/lib is created which contains the current state of
-the `theories/` files (except those which are absolutely necessary for
-building Coq).
+the `theories/` files.
 
-The development of the library continues in this repository and respects
+The development of the library continues in this repository and follows
 semantic versioning.
 
 ## Semantic versioning means:
@@ -94,11 +93,8 @@ of Isabelle (and contribution models of other provers, e.g. Mizar, ACL2...).
 The main drawback is that the split makes it harder to continue compiling
 Coq and its library. We discuss the proposed solution here.
 
-Expect the `Init/` sub-directory, everything in `theories/` would be
-ignored by git. This can be achieved by adding to `.gitignore`:
-
-    theories/*
-    !theories/Init/
+We make git ignore the `theories/` directory. This folder will continue
+to serve the purpose of developing and building the library.
 
 Calling a special make target would look for a git repository at `theories/dev/`.
 If it exists, it would fetch and checkout the latest changes from the master
@@ -147,11 +143,15 @@ times in the past. To me this question should be postponed until the new
 development model is well tested. Then this question can be asked again
 with more confidence (if it still seems to be relevant).
 
-- There might be technical problems doing the split. I don't have enough
-knowledge to gauge the difficulty of having Coq compile without most of
-its `theories/` files. Some plugins in particular might be very dependent
-on part of the standard library (e.g. nsatz). Can we keep them in the main
-repository at first? It would reduce the level of changes needed.
+- Some plugins (omega, nsatz...) depend on the library. There are two
+solutions here: either move them to the new repository, or keep them
+where they are for now and make the efforts so that plugins continue
+to be compatible with the various versions of the library.
+The second solution has the advantage to reduce the amount of changes
+required by the move, but it can turn out to be more complicated to
+manage in the long run.
+Keeping them where they are at the beginning does not prevent to move
+them later though.
 
 # Perspectives
 

--- a/text/000-versioned-stdlib.md
+++ b/text/000-versioned-stdlib.md
@@ -91,6 +91,12 @@ All the other versions, including the development version, are accessible
 through OPAM packages, or by manually downloading and compiling the
 corresponding archives.
 
+More precisely, the OPAM package for Coq would not include the standard
+library nor the plugins anymore. There would be additional packages for
+those. External developments distributed through OPAM would specify the
+version (or version range) of Coq they depend on, but also the version
+(or version range) of the library they require.
+
 ## Call for contributors
 
 Once the split is done, it would be a good thing for the library to have
@@ -167,6 +173,15 @@ required by the move, but it can turn out to be more complicated to
 manage in the long run.
 Keeping them where they are at the beginning does not prevent to move
 them later though.
+
+- Since several versions of the library may be installed in parallel, we
+need to be able to tell Coq which version (or version range) of the library
+to use. This could be achieved with an option of coqtop / coqc (thus it
+would be specified in `_CoqProject`) or with a new command (then it would
+be set inside the document). The first solution is probably better because
+with the second, what to do in case of conflicting such commands? In any
+case, we probably want (if no such option / command is used) the default to
+be the latest stable version available.
 
 # Perspectives
 

--- a/text/000-versioned-stdlib.md
+++ b/text/000-versioned-stdlib.md
@@ -56,15 +56,30 @@ probably not be buggy and thus patch level versions should be quite rare.
 There is one branch per released major version (the stable branches, which
 are named v1, v2, v3...) plus the master branch.
 
-Breaking changes are always done on the master branch only.
+Breaking changes are *always* done on the master branch only.
+When maintainers agree that it is time, the development version (master
+branch) can become the new stable version: a new branch is created
+to track this stable version; while breaking changes continue to happen
+only on master.
 
-Non-breaking changes are always done on the latest stable branch, then
-merged into the master branch.
+Non-breaking changes are *always* done on the latest stable branch, then
+merged into the master branch. Minor and patch level releases can happen
+much more often than major releases and would consist in tagging a
+specific commit on the latest stable branch and creating an OPAM package.
 
 All the supported versions of the library (the development version, the
 stable version and possibly a few legacy versions, i.e. older stable
-versions) are checked to compile with all the supported versions of Coq
-(thanks to automatic testing jobs).
+versions) are checked to compile with all the supported, *more recent*,
+versions of Coq (thanks to automatic testing jobs).
+
+This means that newer versions of the library can use newly introduced
+features of Coq, but that new versions of Coq cannot break compatibility
+with supported versions of the library.
+
+There would not be any fixed release schedule to start with: if this is
+seen like something useful to have, it would have to be discussed and
+decided by the maintainers once the new development practices are well
+established.
 
 ## Distribution
 


### PR DESCRIPTION
Summary
=======

Versioning the standard library independently from Coq itself is important for better compatibility, especially in a development model where new versions of Coq are quite frequent.

For practical reasons, this is better done by moving the `theories/` files out of the main repository and into a specific coq/lib repository.

This move will also be a perfect opportunity to make sure that users are encouraged to contribute to the improvement of the library, and possibly to find additional maintainers coming from the user community.

--------

I wanted to start this CEP after a discussion about compatibility with @herbelin and @ejgallego on https://github.com/coq/coq/pull/140#issuecomment-286724361.

It draws inspiration from demand of users such as Michael Soegtrop. I also had some very preliminary discussions with e.g. @amahboubi.

I had a first review of this CEP offline with Hugo, Matthieu and Daniel, but this is still in a very preliminary state. I would appreciate your comments in order to make it better.