### PR TITLE
User-defined rewrite rules

### DIFF
--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -51,10 +51,10 @@ Patterns obey the following syntax:
 ```
 p ::= ?x y₁ ... yₙ         pattern variable (applied to all bound variables)
     | C p₁ ... pₙ          constructor applied to patterns
-    | I p₁ ... pₙ          type-constructor applied to patterns
+    | I p₁ ... pₙ          Inductive type constructor applied to patterns
     | λ x : p₁, p₂         λ-abstraction over patterns
     | ∀ x : p₁, p₂         Π-type of patterns
-    | !{t}                 forced term
+    | !{t}                 type-forced term
 ```
 
 A lhs must depend on all the pattern variables in scope while the rhs can depend

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -1,29 +1,83 @@
-- Title: Rewrite Rules
-- Drivers: Gaëtan, Théo
+- Title: User-defined rewrite rules
+- Drivers: Gaëtan Gilbert, Nicolas Tabareau, Théo Winterhalter
 
 ----
 
 # Summary
 
-We want to add rewrite rules to Coq.
+We want to add user-defined rewrite rules to Coq. They would complement the
+axiom mechanism of Coq by allowing users to define their own computation rules.
 
 # Motivation
 
-They're cool.
+At the moment users can extend the theory of Coq by assuming extra constructions
+using `Axiom` but they cannot assume any computational behaviour.
+With rewrite rules, users could also postulate new reduction rules.
+This could have various use cases:
+- Adding new reduction rules to neutral terms (eg. allowing both `0 + n` and
+`n + 0` to reduce to `0`).
+- Postulating otherwise rejected inductive types with computation rules for
+their eliminator (eg. quotient types or higher inductive types).
+- Defining functions using a mechanism more powerful that the usual
+pattern-matching.
 
-# Design
+# Detailed design
+
+Rewrite rules are mainly given by two components: a left- and a right-hand-side
+that both live in a given context (or scope) of pattern variables.
+(Rewrite rules are not typed.)
 
 Rules look like
 
-```
-?x ?y ?z |- lhs => rhs
+```coq
+?x ?y ?z ⊢ lhs ⇒ rhs
 ```
 
-where lhs is a pattern (todo define) depending on all pattern
-variables `?x ?y ?z` and rhs is an arbitrary term depending on some of
-the pattern variables.
+where `lhs` obey the following syntax and `rhs` can be an arbitrary term.
 
-Patterns may be
-- pattern variables
-- symbols (axioms) applied to patterns
-- ...
+```
+lhs ::= symbol                                   a symbol
+      | lhs p                                    lhs applied to a pattern
+      | lhs .proj                                projection of a lhs
+      | match lhs with p₁ ... pₙ                 pattern-matching of a lhs
+```
+
+Symbols are rigid terms, typically axioms. We could in principle allow for
+more terms to qualify as symbols such as definitions (constants). It is up to
+the user to make sure that the rules make sense and are applicable.
+In the case of pattern-matching, all the branches are patterns as well.
+Patterns obey the following syntax:
+
+```
+p ::= ?x                   pattern variable
+    | C p₁ ... pₙ          constructor applied to patterns
+    | λ x : p₁, p₂         λ-abstraction over patterns
+    | ∀ x : p₁, p₂         Π-type of patterns
+    | ...
+```
+
+A lhs must depend on all the pattern variables in scope while the rhs can depend
+on a subset of those.
+
+Rewrite rules are triggered when a term is stuck with respect to the regular
+rules of Coq.
+
+# Drawbacks
+
+This proposal concerns unsafe rewrite rules. As such, uncareful rewrite rules
+could lead to infinite loops in the reduction machine or worse to anomalies
+(by breaking subject reduction for instance).
+More generally, rules can break confluence and result in incompleteness from
+the type checker which might reject conversion of two convertible terms in
+the extended theory.
+These drawbacks can be in part alleviated by implementing a modular confluence
+checker as advocated in the paper "The Taming of the Rew" and as is currently
+implemented in Agda by Jesper Cockx.
+
+# Alternatives
+
+The Agda implementation of rewrite rules is very much related to this.
+There were of course many other attempts to integrate rewrite rules in the past
+like Coq Modulo Theory and the work of Bruno Barras.
+
+# Unresolved questions

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -26,7 +26,6 @@ pattern-matching.
 
 Rewrite rules are mainly given by two components: a left- and a right-hand-side
 that both live in a given context (or scope) of pattern variables.
-(Rewrite rules are not typed.)
 
 Rules look like
 
@@ -55,6 +54,7 @@ p ::= ?x y₁ ... yₙ         pattern variable (applied to all bound variables)
     | I p₁ ... pₙ          type-constructor applied to patterns
     | λ x : p₁, p₂         λ-abstraction over patterns
     | ∀ x : p₁, p₂         Π-type of patterns
+    | !{t}                 forced term
 ```
 
 A lhs must depend on all the pattern variables in scope while the rhs can depend

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -123,6 +123,40 @@ with rules
   J ?A ?x ?P ?p !{x} (@eq_refl !{A} !{x}) := p.
 ```
 
+### Higher-inductive types
+
+HoTT users might want to use rewrite rules to define HIT rather than use the
+current notion of private inductive types.
+
+```coq
+Rewrite Block :=
+  S¹ : Type ;
+  base : S¹ ;
+  loop : base = base ;
+  elimS¹ : ∀ (P : S¹ → Type) (b : P base) (l : loop # b = b) x, P x ;
+  elimS¹ₗₒₒₚ : ∀ (P : S¹ → Type) (b : P base) (l : loop # b = b),
+                apD (elimS¹ P b l) loop = loop
+with rules
+  elimS¹ ?P ?b ?l base := b.
+```
+
+### Quotients
+
+We can also postulate quotients with a way to lift functions to the quotient.
+This example also illustrates how we could combine this syntax with notations.
+
+```coq
+Rewrite Block :=
+  Quotient : ∀ A, (A → A → Prop) → Type ;
+  proj : A → A // R ;
+  quot : ∀ x y, R x y → proj x = proj y ;
+  rec : ∀ {A R B} (f : A → B), (∀ x y, R x y → f x = f y) → A // R → B
+with rules
+  rec ?f ?q (proj ?x) := f x
+where
+  "A // R" := (Quotient A R).
+```
+
 ## Possible extensions
 
 Coq [CEP#45]'s integration might make it possible to add rewrite rules to

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -1,0 +1,29 @@
+- Title: Rewrite Rules
+- Drivers: Gaëtan, Théo
+
+----
+
+# Summary
+
+We want to add rewrite rules to Coq.
+
+# Motivation
+
+They're cool.
+
+# Design
+
+Rules look like
+
+```
+?x ?y ?z |- lhs => rhs
+```
+
+where lhs is a pattern (todo define) depending on all pattern
+variables `?x ?y ?z` and rhs is an arbitrary term depending on some of
+the pattern variables.
+
+Patterns may be
+- pattern variables
+- symbols (axioms) applied to patterns
+- ...

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -42,8 +42,7 @@ lhs ::= symbol                                   a symbol
       | match lhs with p₁ ... pₙ                 pattern-matching of a lhs
 ```
 
-Symbols are rigid terms, typically axioms. We could in principle allow for
-more terms to qualify as symbols such as definitions (constants). It is up to
+Symbols are rigid terms, typically axioms. It is up to
 the user to make sure that the rules make sense and are applicable.
 In the case of pattern-matching, all the branches are patterns as well.
 Patterns obey the following syntax:

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -20,6 +20,7 @@ This could have various use cases:
 their eliminator (eg. quotient types or higher inductive types).
 - Defining functions using a mechanism more powerful that the usual
 pattern-matching.
+- Define extension of CIC such as Exceptional Type Theory or Setoid Type Theory
 
 # Detailed design
 
@@ -71,8 +72,8 @@ More generally, rules can break confluence and result in incompleteness from
 the type checker which might reject conversion of two convertible terms in
 the extended theory.
 These drawbacks can be in part alleviated by implementing a modular confluence
-checker as advocated in the paper "The Taming of the Rew" and as is currently
-implemented in Agda by Jesper Cockx.
+checker as advocated in the paper[The Taming of the Rew](https://hal.archives-ouvertes.fr/hal-02901011)
+and as is currently implemented in Agda by Jesper Cockx.
 
 # Alternatives
 

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -52,9 +52,9 @@ Patterns obey the following syntax:
 ```
 p ::= ?x y₁ ... yₙ         pattern variable (applied to all bound variables)
     | C p₁ ... pₙ          constructor applied to patterns
+    | I p₁ ... pₙ          type-constructor applied to patterns
     | λ x : p₁, p₂         λ-abstraction over patterns
     | ∀ x : p₁, p₂         Π-type of patterns
-    | ...
 ```
 
 A lhs must depend on all the pattern variables in scope while the rhs can depend

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -20,7 +20,7 @@ This could have various use cases:
 their eliminator (eg. quotient types or higher inductive types).
 - Defining functions using a mechanism more powerful that the usual
 pattern-matching.
-- Define extension of CIC such as Exceptional Type Theory or Setoid Type Theory
+- Define extensions of CIC such as Exceptional Type Theory or Setoid Type Theory
 
 # Detailed design
 

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -15,7 +15,7 @@ using `Axiom` but they cannot assume any computational behaviour.
 With rewrite rules, users could also postulate new reduction rules.
 This could have various use cases:
 - Adding new reduction rules to neutral terms (eg. allowing both `0 + n` and
-`n + 0` to reduce to `0`).
+`n + 0` to reduce to `n`).
 - Postulating otherwise rejected inductive types with computation rules for
 their eliminator (eg. quotient types or higher inductive types).
 - Defining functions using a mechanism more powerful that the usual

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -49,7 +49,7 @@ In the case of pattern-matching, all the branches are patterns as well.
 Patterns obey the following syntax:
 
 ```
-p ::= ?x                   pattern variable
+p ::= ?x y₁ ... yₙ         pattern variable (applied to all bound variables)
     | C p₁ ... pₙ          constructor applied to patterns
     | λ x : p₁, p₂         λ-abstraction over patterns
     | ∀ x : p₁, p₂         Π-type of patterns

--- a/text/xxx-rewrite-rules.md
+++ b/text/xxx-rewrite-rules.md
@@ -72,7 +72,7 @@ More generally, rules can break confluence and result in incompleteness from
 the type checker which might reject conversion of two convertible terms in
 the extended theory.
 These drawbacks can be in part alleviated by implementing a modular confluence
-checker as advocated in the paper[The Taming of the Rew](https://hal.archives-ouvertes.fr/hal-02901011)
+checker as advocated in the paper [The Taming of the Rew](https://hal.archives-ouvertes.fr/hal-02901011)
 and as is currently implemented in Agda by Jesper Cockx.
 
 # Alternatives


### PR DESCRIPTION
We propose an extension of Coq with user-defined rewrite rules, following our work on formalising rewrite rules in MetaCoq and the paper [The Taming of the Rew].

[Rendered here].

[The Taming of the Rew]: https://hal.archives-ouvertes.fr/hal-02901011
[Rendered here]: https://github.com/CoqHott/ceps/blob/rew/text/xxx-rewrite-rules.md