### PR TITLE
Short-term roadmap for Coq

### DIFF
--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -150,6 +150,9 @@ Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
 #### Ltac2
 
 - Gaëtan Gilbert, Pierre-Marie Pédrot
+- long term
+
+The goal is to get to the point where we can recommend new developments be Ltac2 only (no Ltac1).
 
 #### Arbitrary recursive notations
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -89,11 +89,21 @@ to add and remove items, to reflect the evolution of the project.
 
 #### Rewrite rules
 
-The goal is to add (unsafe) user-defined rewrite rules. This features allows users to add computation rules to axioms which can be useful for prototyping. It also allows for different kinds of computation rules with respect to what Coq currently permits: non-linearity, overlapping left-hand sides (*eg* one can write an addition on natural numbers that reduces on both sides: `0 + n` and `n + 0` both reducing to `n`).
+The goal is to add (unsafe) user-defined rewrite rules. This features allows
+users to add computation rules to axioms which can be useful for prototyping.
+It also allows for different kinds of computation rules with respect to what Coq
+currently permits: non-linearity, overlapping left-hand sides (*eg* one can write
+an addition on natural numbers that reduces on both sides: `0 + n` and `n + 0`
+both reducing to `n`).
 
-It would be deactivated by default and be optionally on by *eg* setting `Rewrite Rules On`. They should be supported by unification and the main reduction machines (not `vm_compute` and `native_compute` for now, Coq should give a warning when those are used with rewrite rules on). Rewrite rules would propagate to any module that requires the module that defines them.
+It would be deactivated by default and be optionally on by *eg* setting
+`Rewrite Rules On`. They should be supported by unification and the main
+reduction machines (not `vm_compute` and `native_compute` for now, Coq
+should give a warning when those are used with rewrite rules on). Rewrite
+rules would propagate to any module that requires the module that defines them.
 
-- Working Coq fork: https://github.com/Yann-Leray/coq (examples in https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.v).
+- Working Coq fork: https://github.com/Yann-Leray/coq (examples in
+https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.v).
 - CEP: https://github.com/coq/ceps/pull/50
 - Yann Leray, Théo Winterhalter
 - 3 to 6 month

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -30,8 +30,8 @@ Producing a roadmap for the Coq project is important for several reasons:
   efficient, by making sure that their work will be supported by other
   developers, including reviewers.
 
-- It helps contributors to know what are the important axes where their
-  contribution is most likely to be welcome and where they can expect
+- It helps contributors to know in what areas their
+  contribution is likely to get
   the most support from the Coq developers.
 
 - It helps highlighting the axes where more resources are needed, and

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -159,23 +159,21 @@ for more peripherical changes, for instance on user contributions.
 
 ### Kernel, theory
 
-#### Sort polymorphism
+#### Template polymorphism
 
-- Gaëtan Gilbert, Nicolas Tabareau
-- DONE (8.19)
-- ongoing PR https://github.com/coq/coq/pull/17836 (will need a followup for inductives)
+- Gaëtan Gilbert, Pierre Maria Pédrot
+- in progress (maybe done by 8.21)
+- notably https://github.com/coq/coq/pull/19228
 
-Extension of universe polymorphism to sort qualities. It becomes possible to have global references quantified over 
-sort qualities eg `foo@{s | u | } : Type@{s | u}` which could be instantiated to `foo@{SProp | v} : SProp` 
-(the quantification syntax needs both `|` to avoid ambiguity).
+Make template poly more usable and more robust, basing the metatheory on sort poly.
 
-This should allow having for instance a common inductive for SProp, Prop and Type instantations of sigma types 
-(instead of the current `sigT` `sig` `ex` and variations depending on if each of the 2 parameters and the output are SProp).
+TODO:
 
-Eventually may allow using a common implementation for Type and Prop setoid rewriting machinery 
-(`Morphisms` vs `CMorphisms`, `RelationClasses` vs `CRelationsClasses`).
-
-May also be useful when doing Observational Type Theory.
+- metatheory in metacoq (?)
+- allow template univs which don't appear in the conclusion
+  (eg `u` in `eq : forall A:Type@{u}, A -> A -> Prop`)
+- remove above-Prop restriction in template poly (?)
+- I feel like I forgot something but can't remember what
 
 #### Algebraic universes
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -222,6 +222,13 @@ Other aspects that need re-examination because they are problematic already in t
 - Module dependency analysis
 - Hugo Herbelin + Yannick Forster
 
+#### Attaching comments to declarations
+
+- Hugo Herbelin + ??
+- time needed to converge on the design
+
+PR [#18193](https://github.com/coq/coq/pull/18193) implements a table for binding comments to declarations, but it lacks surface syntax.
+
 ### Cleanup
 
 #### Retiring the STM, step 1

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -324,7 +324,7 @@ In particular, we should:
 
 The technical details (prelude content, split into packages, logpath,
 mono/multi repo, call for maintainers, documentation, test-suite,
-CI,...) will be discussed in a [CEP](https://github.com/coq/ceps/) to
+CI,...) will be discussed in this CEP: https://github.com/coq/ceps/pull/83 to
 ensure a reasonnable agreement is reached on those points before
 implementing any actual change.
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -239,7 +239,7 @@ Resources:
 
 ### Libraries and community
 
-#### Demote stdlib
+#### Boost stdlib development
 
 As part of the promotion effort around the Coq Platform, we would like to
 ensure that the stdlib does not enjoy special status and that Coq can be
@@ -268,6 +268,12 @@ In particular, we should:
   Stop including any other stdlib components as part of the `coq` opam
   package and encourage maintainers of Coq packages in other distributions
   to do the same.
+
+The technical details (prelude content, split into packages, logpath,
+mono/multi repo, call for maintainers, documentation, test-suite,
+CI,...) will be discussed in a [CEP](https://github.com/coq/ceps/) to
+ensure a reasonnable agreement is reached on those points before
+implementing any actual change.
 
 Resources:
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -36,7 +36,7 @@ Producing a roadmap for the Coq project is important for several reasons:
   to receive the most support from the Coq developers.
 
 - It helps highlighting other priorities where progress is not possible for
-  lack of resources are needed, and where the Coq project should aim to find
+  lack of resources, and where the Coq project should aim to find
   more resources.
 
 # Detailed design

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -174,6 +174,8 @@ able to define global tables with several kind of indices through a vernacular
 and extend them after the fact. With this feature, mutable definitions are just
 a specific case of tables with a unit index.
 
+`coqdoc` needs to understand Ltac2 (link to definitions, skip bodies).
+
 - Gaëtan Gilbert, Pierre-Marie Pédrot, (Enrico Tassi for the SSR part)
 - long term
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -183,14 +183,54 @@ Would require work on:
 
 #### Promote the Coq Platform
 
-- Théo Zimmermann, ???
+The Coq Platform is already the officially recommended installation method.
+We would like to make it clear to users that they are encouraged to rely on
+the packages that it provides, and that libraries in the Platform should be
+generally considered as a collaborative extended standard library for Coq
+(the historical stdlib being only a part of this).
 
-Editorial work + documentation
+As part of this effort we should do:
+
+- Editorial work for curation of packages included in the Coq Platform
+  (to bring guarantees on their level of quality).
+
+- Consolidation of documentation, so that it is easy for users to find
+  documentation about the included packages, ideally with a consistant
+  presentation.
+
+- Infrastructure / automation work to stabilize the release process of
+  the Coq Platform and ensure that releases are more consistently
+  delivered according to a predefined schedule.
 
 #### Demote stdlib
 
-- Separation of the prelude
-- Make stdlib a normal library
+As part of the promotion effort around the Coq Platform, we would like to
+ensure that the stdlib does not enjoy special status and that Coq can be
+used without it. We should consider stdlib components as libraries to
+advertise for their own values as part of the Coq Platform packages, but
+without their historical origin, or their development and release process
+being tied to Coq, (mis)leading users to consider them as the only
+officially recommended libraries.
+
+In particular, we should:
+
+- Identify consistent stdlib components that can be used independently
+  from each other and that would be worth distributing as separate
+  packages. Identify their maintainers and give them freedom to define
+  the future of the components they maintain, in the limits set by the
+  Coq Platform charter. Allow maintainers to extract stdlib components
+  to maintain and evolve them outside the core Coq repository and to have
+  their own release schedule and versioning scheme, in case they wish to
+  do so.
+
+- Extract the prelude + a minimum set of components that alternative
+  general libraries like MathComp and coq-stdpp need as a basis.
+  Make sure that this reduced core stdlib component can evolve to allow
+  other libraries to use newer features of Coq (like universe polymorphism,
+  SProp and primitive projections).
+  Stop including any other stdlib components as part of the `coq` opam
+  package and encourage maintainers of Coq packages in other distributions
+  to do the same.
 
 #### Tooling for building libraries
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -189,7 +189,7 @@ Resources:
 
 ### Libraries and community
 
-#### Move stdlib to coq-community
+#### Demote stdlib
 
 As part of the promotion effort around the Coq Platform, we would like to
 ensure that the stdlib does not enjoy special status and that Coq can be

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -75,9 +75,9 @@ to add and remove items, to reflect the evolution of the project.
 
 ## Priorities and resources
 
-### Change of Name: Coq -> Rocq
+### Change of Name: `Coq` -> `Rocq`
 
-- Yves Bertot, Nicolas TAbareau
+- Yves Bertot, Nicolas Tabareau
 - 3 to 6 months
 
 The Coq developer team has validated the renaming of Coq into Rocq. There are several steps to make this happen. 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -162,7 +162,7 @@ for more peripherical changes, for instance on user contributions.
 #### Sort polymorphism
 
 - Gaëtan Gilbert, Nicolas Tabareau
-- 3 to 6 months
+- DONE (8.19)
 - ongoing PR https://github.com/coq/coq/pull/17836 (will need a followup for inductives)
 
 Extension of universe polymorphism to sort qualities. It becomes possible to have global references quantified over 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -143,10 +143,10 @@ https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.
 
 #### Guard condition
 
-- Guard condition able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR #17950), a few weeks for discussions and reviewing
-- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR #17986), a few weeks for discussions and reviewing
+- Guard condition able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR coq/coq#17950), a few weeks for discussions and reviewing
+- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR coq/coq#17986), a few weeks for discussions and reviewing
 - Expanded constructors of a branch in a `match` considered smaller for the guard condition (CEP #73), a few weeks depending on discussions
-- Refinement of the guard condition through `match` constructs (PR #14359), a few weeks for discussions and reviewing
+- Refinement of the guard condition through `match` constructs (PR coq/coq#14359), a few weeks for discussions and reviewing
 
 #### Sections
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -141,6 +141,17 @@ https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.
 - Yann Leray, Théo Winterhalter
 - 3 to 6 month
 
+#### Guard condition
+
+- Guard condition able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR #17950), a few weeks for discussions and reviewing
+- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR #17986), a few weeks for discussions and reviewing
+- Expanded constructors of a branch in a `match` considered smaller for the guard condition (CEP #73), a few weeks depending on discussions
+- Refinement of the guard condition through `match` constructs (PR #14359), a few weeks for discussions and reviewing
+
+#### Sections
+
+- Design of a way to refer to the generalized version of a constant/inductive from within the inside of a section (depends on the time needed to reach a consensus on the design)
+
 #### Primitive projections
 
 Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
@@ -230,12 +241,9 @@ Resources:
 
 #### Observational type theory
 
-#### Fixpoints
+#### Global fixpoints
 
-- Global fixpoints: Hugo less convinced of the importance of global fixpoints vs modifying the fix/cofix rules of CIC so that they unfold for named fixpoints on the name rather than the body of the fix
-- Fixpoints able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR #17950), a few weeks
-- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR #17986), a few weeks
-- Expanded constructors of a branch in a `match` considered smaller for the guard condition (CEP #73)
+- Hugo less convinced of the importance of global fixpoints vs modifying the fix/cofix rules of CIC so that they unfold for named fixpoints on the name rather than the body of the fix
 
 #### Primitive projections
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -75,6 +75,28 @@ to add and remove items, to reflect the evolution of the project.
 
 ## Priorities and resources
 
+### Change of Name: Coq -> Rocq
+
+- Yves Bertot, Nicolas TAbareau
+- 3 to 6 months
+
+The Coq developer team has validated the renaming of Coq into Rocq. There are several steps to make this happen. 
+
+#### Legal issues 
+
+We are checking that we can actually use the new name from a legal point of view. 
+
+#### Visual identity and website
+
+The change of name is an opportunity to redesign the visual identity of Rocq
+and to give a fresher look to the historical website of Coq. 
+
+#### Technical issues 
+
+On the technical issues, the renaming practically means a huge amount of search&replace 
+in many parts of the code base and website links. We may ask also for user contributions 
+for more peripherical changes. 
+
 ### Kernel, theory
 
 #### Sort polymorphism

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -1,6 +1,6 @@
 - Title: Coq roadmap
 
-- Drivers: Théo Zimmermann (@Zimmi48)
+- Drivers: Nicolas Tabareau (@tabareau), Théo Zimmermann (@Zimmi48)
 
 ----
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -195,7 +195,7 @@ As part of this effort we should do:
   (to bring guarantees on their level of quality).
 
 - Consolidation of documentation, so that it is easy for users to find
-  documentation about the included packages, ideally with a consistant
+  documentation about the included packages, ideally with a consistent
   presentation.
 
 - Infrastructure / automation work to stabilize the release process of

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -75,12 +75,13 @@ to add and remove items, to reflect the evolution of the project.
 
 ## Priorities and resources
 
-### Change of Name: `Coq` -> `Rocq`
+### Change of Name: `Coq` -> `The Rocq Prover`
 
 - Yves Bertot, Nicolas Tabareau
 - 3 to 6 months
 
-The Coq developer team has validated the renaming of Coq into Rocq. There are several steps to make this happen. 
+The Coq developer team has validated the renaming of Coq into the Rocq Prover. 
+There are several steps to make this happen. 
 
 #### Legal issues 
 
@@ -88,14 +89,14 @@ We are checking that we can actually use the new name from a legal point of view
 
 #### Visual identity and website
 
-The change of name is an opportunity to redesign the visual identity of Rocq
+The change of name is an opportunity to redesign the visual identity of the Rocq Prover
 and to give a fresher look to the historical website of Coq. 
 
 #### Technical issues 
 
 On the technical issues, the renaming practically means a huge amount of search&replace 
-in many parts of the code base and website links. We may ask also for user contributions 
-for more peripherical changes. 
+in many parts of the code base, website links, etc. We may ask for user contributions 
+for more peripherical changes, for instance on user contributions. 
 
 ### Kernel, theory
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -386,6 +386,9 @@ a specific case of tables with a unit index.
 
 #### Parsing
 
+- Hugo Herbelin, Pierre Roux
+- 2 years
+
 We plan to remove the recovery mechanism of the camlp5/coqpp parsing
 engine (see [#17876](https://github.com/coq/coq/pull/17876)). This
 will make the parser simpler and easier to understand and will enable

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -89,7 +89,8 @@ to add and remove items, to reflect the evolution of the project.
 
 #### Rewrite rules
 
-- Yann ?, Théo Winterhalter
+- Yann Leray, Théo Winterhalter
+- 3 to 6 month
 
 #### Primitive projections
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -141,13 +141,20 @@ Would require work on:
 
 #### Observational type theory
 
-#### Global fixpoints
+#### Fixpoints
+
+- Global fixpoints: Hugo less convinced of the importance of global fixpoints vs modifying the fix/cofix rules of CIC so that they unfold for named fixpoints on the name rather than the body of the fix
+- Fixpoints able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR #17950), a few weeks
+- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR #17986), a few weeks
+- Expanded constructors of a branch in a `match` considered smaller for the guard condition (CEP #73)
 
 #### Primitive projections
 
 - Removal of compatibility layer
 
 #### Sections
+
+- Design of a way to refer to the generalized version of a constant/inductive from within the inside of a section
 
 #### Modules
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -160,10 +160,22 @@ Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
 
 #### Ltac2
 
+The overarching goal is to get to the point where we can recommend new
+developments to only use Ltac2 (without having to load Ltac1). There are several
+fronts on which to make progress.
+
+One major point is to make available in Ltac2 all the basic tactics from Ltac1.
+The main missing part is currently the ssreflect framework. Exposing it in Ltac2
+implies writing a good chunk of boilerplate binding code for the Ltac2-OCaml FFI
+and defining the corresponding grammar rules for the Ltac2 language.
+
+Another important thing for extensibility is the table feature. One should be
+able to define global tables with several kind of indices through a vernacular
+and extend them after the fact. With this feature, mutable definitions are just
+a specific case of tables with a unit index.
+
 - Gaëtan Gilbert, Pierre-Marie Pédrot
 - long term
-
-The goal is to get to the point where we can recommend new developments be Ltac2 only (no Ltac1).
 
 #### General recursive notations
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -174,7 +174,7 @@ able to define global tables with several kind of indices through a vernacular
 and extend them after the fact. With this feature, mutable definitions are just
 a specific case of tables with a unit index.
 
-- Gaëtan Gilbert, Pierre-Marie Pédrot
+- Gaëtan Gilbert, Pierre-Marie Pédrot, (Enrico Tassi for the SSR part)
 - long term
 
 #### General recursive notations

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -1,0 +1,180 @@
+- Title: Coq roadmap
+
+- Drivers: Théo Zimmermann
+
+----
+
+# Summary
+
+This CEP aims to establish a roadmap for the Coq project.
+It highlights both:
+
+- what are considered as important axes to work on in the future,
+- what resources are available to work on these axes, and which axes we commit
+  to work on based on these resources.
+
+Resources mean availability of persons to conduct the work. For technical axes,
+requiring changes in the Coq system, it includes availability of persons to
+review and merge the changes.
+
+# Motivation
+
+Producing a roadmap for the Coq project is important for several reasons:
+
+- It helps the community to know what to expect from the Coq project in the
+  future, in particular what changes can reasonably be expected to become
+  part of next releases, and what changes are more likely to be delayed
+  because of lack of resources.
+
+- It helps Coq developers to focus on important axes, and to be more
+  efficient, by making sure that their work will be supported by other
+  developers, including reviewers.
+
+- It helps contributors to know what are the important axes where their
+  contribution is most likely to be welcome and where they can expect
+  the most support from the Coq developers.
+
+- It helps highlighting the axes where more resources are needed, and
+  where the Coq project should try to find more resources.
+
+# Detailed design
+
+This roadmap is a consolidated view created by the Coq developers, based on
+their shared understanding of the priorities of the project and of the
+resources available to work on these priorities. It is completed by a
+discussion with the community, as part of the CEP process.
+
+The fact that an item is part of the roadmap does not mean that its design
+is already fixed, as design can be part of the work to be done. Therefore,
+disagreement can still arise on such items, and may require to be resolved
+through PR reviews, or through the CEP process. However, if an item is
+part of the roadmap, it means that the Coq developers are committed to
+work on it, and that they have resources available to do so, including the
+reviews, so the work should not stall because of lack of resources or lack
+of interest.
+
+Rules :
+
+- An item cannot be part of the roadmap if it is not supported by at least
+  two persons, including at least one Coq maintainer to review the changes.
+- No one should be committed to work on more than two items at the same time.
+
+## Priorities and resources
+
+### Kernel, theory
+
+#### Sort polymorphism
+
+- Gaëtan Gilbert, Nicolas Tabareau
+- 3 to 6 months
+
+#### Algebraic universes
+
+- Matthieu Sozeau, Pierre-Marie Pédrot
+- 1 year
+
+#### Rewrite rules
+
+- Yann ?, Théo Winterhalter
+
+#### Primitive projections
+
+Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
+
+### Surface language
+
+#### Ltac2
+
+- Gaëtan Gilbert, Pierre-Marie Pédrot
+
+#### AST / interpretation
+
+- Emilio? (probably to remove because other Emilio commitments)
+
+#### Arbitrary recursive notations
+
+- Hugo Herbelin, Pierre Roux
+
+#### Bi-dimensional notations
+
+- Emilio Jésus Gallego Arias, ??? (missing buddy)
+
+#### Nametab / libobject
+
+- Emilio Jésus Gallego Arias, ??? (missing buddy)
+
+### Tools
+
+#### Proved extraction
+
+- Yannick Forster, Matthieu Sozeau
+- 6 months to 1 year
+
+Would require work on:
+
+- Prop included in Type
+- Module dependency analysis
+- Hugo Herbelin + Yannick Forster
+
+### Libraries and community
+
+#### Promote the Coq Platform
+
+- Théo Zimmermann, ???
+
+Editorial work + documentation
+
+## Other axes, without resources
+
+### Kernel, theory
+
+#### Observational type theory
+
+#### Global fixpoints
+
+#### Primitive projections
+
+- Removal of compatibility layer
+
+#### Sections
+
+#### Modules
+
+### Surface language
+
+#### Removing clenv
+
+#### Unifall
+
+#### Unification heuristics
+
+(improving evarconv)
+
+#### Support for async tactics
+
+#### Reactive elaboration
+
+#### Functionalisation
+
+### Libraries and community
+
+#### Demote stdlib
+
+- Separation of the prelude
+- Make stdlib a normal library
+
+#### Tooling for building libraries
+
+(Coq universe)
+
+# Drawbacks
+
+Is the proposed change affecting any other component of the system? How?
+
+# Alternatives
+
+Yes, do the related works.  What do other systems do?
+
+# Unresolved questions
+
+Questions about the design that could not find an answer.

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -81,6 +81,19 @@ to add and remove items, to reflect the evolution of the project.
 
 - Gaëtan Gilbert, Nicolas Tabareau
 - 3 to 6 months
+- ongoing PR https://github.com/coq/coq/pull/17836 (will need a followup for inductives)
+
+Extension of universe polymorphism to sort qualities. It becomes possible to have global references quantified over 
+sort qualities eg `foo@{s | u | } : Type@{s | u}` which could be instantiated to `foo@{SProp | v} : SProp` 
+(the quantification syntax needs both `|` to avoid ambiguity).
+
+This should allow having for instance a common inductive for SProp, Prop and Type instantations of sigma types 
+(instead of the current `sigT` `sig` `ex` and variations depending on if each of the 2 parameters and the output are SProp).
+
+Eventually may allow using a common implementation for Type and Prop setoid rewriting machinery 
+(Morphisms vs CMorphisms, RelationClasses vs CRelationsClasses).
+
+May also be useful when doing Observational Type Theory.
 
 #### Algebraic universes
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -1,6 +1,6 @@
 - Title: Coq roadmap
 
-- Drivers: Théo Zimmermann
+- Drivers: Théo Zimmermann (@Zimmi48)
 
 ----
 
@@ -53,11 +53,25 @@ work on it, and that they have resources available to do so, including the
 reviews, so the work should not stall because of lack of resources or lack
 of interest.
 
+The description of each item of the roadmap will include the available
+resources, the expected duration of the work, and the expected outcome,
+including any blocking issues that will need to be resolved to complete
+the work, and any still unresolved questions to be answered.
+
 Rules :
 
 - An item cannot be part of the roadmap if it is not supported by at least
   two persons, including at least one Coq maintainer to review the changes.
 - No one should be committed to work on more than two items at the same time.
+
+Each Coq Call will start with a roundtable about progress on items of the
+roadmap.
+
+Gaëtan Gilbert will be the technical coordinator of the roadmap, overseeing
+progress being made.
+
+Théo Zimmermann will be the editorial coordinator of the roadmap, proposing
+to add and remove items, to reflect the evolution of the project.
 
 ## Priorities and resources
 
@@ -87,21 +101,9 @@ Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
 
 - Gaëtan Gilbert, Pierre-Marie Pédrot
 
-#### AST / interpretation
-
-- Emilio? (probably to remove because other Emilio commitments)
-
 #### Arbitrary recursive notations
 
 - Hugo Herbelin, Pierre Roux
-
-#### Bi-dimensional notations
-
-- Emilio Jésus Gallego Arias, ??? (missing buddy)
-
-#### Nametab / libobject
-
-- Emilio Jésus Gallego Arias, ??? (missing buddy)
 
 ### Tools
 
@@ -116,15 +118,7 @@ Would require work on:
 - Module dependency analysis
 - Hugo Herbelin + Yannick Forster
 
-### Libraries and community
-
-#### Promote the Coq Platform
-
-- Théo Zimmermann, ???
-
-Editorial work + documentation
-
-## Other axes, without resources
+## Other axes, without sufficient resources
 
 ### Kernel, theory
 
@@ -142,6 +136,18 @@ Editorial work + documentation
 
 ### Surface language
 
+#### AST / interpretation
+
+- Emilio?
+
+#### Bi-dimensional notations
+
+- Emilio Jésus Gallego Arias, ??? (missing buddy)
+
+#### Nametab / libobject
+
+- Emilio Jésus Gallego Arias, ??? (missing buddy)
+
 #### Removing clenv
 
 #### Unifall
@@ -158,6 +164,12 @@ Editorial work + documentation
 
 ### Libraries and community
 
+#### Promote the Coq Platform
+
+- Théo Zimmermann, ???
+
+Editorial work + documentation
+
 #### Demote stdlib
 
 - Separation of the prelude
@@ -169,12 +181,13 @@ Editorial work + documentation
 
 # Drawbacks
 
-Is the proposed change affecting any other component of the system? How?
+TODO
 
 # Alternatives
 
-Yes, do the related works.  What do other systems do?
+TODO
 
 # Unresolved questions
 
-Questions about the design that could not find an answer.
+- How to update the roadmap? Should this CEP be updated, or should we create new CEPs every few months to produce a new roadmap? Should we
+also maintain a wiki page with the roadmap, to cover the live progress?

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -165,7 +165,9 @@ Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
 
 The goal is to get to the point where we can recommend new developments be Ltac2 only (no Ltac1).
 
-#### Arbitrary recursive notations
+#### General recursive notations
+
+The objective is to grant wish coq/coq#7959 (see there for details).
 
 - Hugo Herbelin, Pierre Roux
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -184,6 +184,43 @@ Resources:
 - Enrico Tassi, ??? I need a code reviewer
 - 1 month of work, 6 months timeframe
 
+### Libraries and community
+
+#### Move stdlib to coq-community
+
+As part of the promotion effort around the Coq Platform, we would like to
+ensure that the stdlib does not enjoy special status and that Coq can be
+used without it. We should consider stdlib components as libraries to
+advertise for their own values as part of the Coq Platform packages, but
+without their historical origin, or their development and release process
+being tied to Coq, (mis)leading users to consider them as the only
+officially recommended libraries.
+
+In particular, we should:
+
+- Identify consistent stdlib components that can be used independently
+  from each other and that would be worth distributing as separate
+  packages. Identify their maintainers and give them freedom to define
+  the future of the components they maintain, in the limits set by the
+  Coq Platform charter. Allow maintainers to extract stdlib components
+  to maintain and evolve them outside the core Coq repository and to have
+  their own release schedule and versioning scheme, in case they wish to
+  do so.
+
+- Extract the prelude + a minimum set of components that alternative
+  general libraries like MathComp and coq-stdpp need as a basis.
+  Make sure that this reduced core stdlib component can evolve to allow
+  other libraries to use newer features of Coq (like universe polymorphism,
+  SProp and primitive projections).
+  Stop including any other stdlib components as part of the `coq` opam
+  package and encourage maintainers of Coq packages in other distributions
+  to do the same.
+
+Resources:
+
+- Cyril Cohen, Pierre Roux
+- 6 months to 1 year
+
 ## Other axes, without sufficient resources
 
 ### Kernel, theory
@@ -257,36 +294,6 @@ As part of this effort we should do:
 - Infrastructure / automation work to stabilize the release process of
   the Coq Platform and ensure that releases are more consistently
   delivered according to a predefined schedule.
-
-#### Demote stdlib
-
-As part of the promotion effort around the Coq Platform, we would like to
-ensure that the stdlib does not enjoy special status and that Coq can be
-used without it. We should consider stdlib components as libraries to
-advertise for their own values as part of the Coq Platform packages, but
-without their historical origin, or their development and release process
-being tied to Coq, (mis)leading users to consider them as the only
-officially recommended libraries.
-
-In particular, we should:
-
-- Identify consistent stdlib components that can be used independently
-  from each other and that would be worth distributing as separate
-  packages. Identify their maintainers and give them freedom to define
-  the future of the components they maintain, in the limits set by the
-  Coq Platform charter. Allow maintainers to extract stdlib components
-  to maintain and evolve them outside the core Coq repository and to have
-  their own release schedule and versioning scheme, in case they wish to
-  do so.
-
-- Extract the prelude + a minimum set of components that alternative
-  general libraries like MathComp and coq-stdpp need as a basis.
-  Make sure that this reduced core stdlib component can evolve to allow
-  other libraries to use newer features of Coq (like universe polymorphism,
-  SProp and primitive projections).
-  Stop including any other stdlib components as part of the `coq` opam
-  package and encourage maintainers of Coq packages in other distributions
-  to do the same.
 
 #### Tooling for building libraries
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -208,7 +208,7 @@ to `@{u v ?| u <= v + 2 ?}`.
 https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.v).
 - CEP: https://github.com/coq/ceps/pull/50
 - Yann Leray, Théo Winterhalter
-- 3 to 6 month
+- DONE (8.20)
 
 The goal is to add (unsafe) user-defined rewrite rules. This feature allows
 users to add computation rules to axioms which can be useful for prototyping.
@@ -276,6 +276,7 @@ Sub items:
 
 - Cyril Cohen, Pierre Roux
 - 6 months to 1 year
+- [CEP #83](https://github.com/coq/ceps/pull/83)
 
 As part of the promotion effort around the Coq Platform, we would like to
 ensure that the stdlib does not enjoy special status and that Coq can be
@@ -322,6 +323,8 @@ is presented at the same level of detail yet.
 
 Short-term work on sort polymorphism should make it easier to adapt
 all tactics and libraries so that `SProp` becomes actually usable.
+
+For tactics it's mostly a matter of waiting for bugs to be reported so we know what it broken.
 
 #### Guard condition
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -202,7 +202,7 @@ to `@{u v ?| u <= v + 2 ?}`.
 
 #### Rewrite rules
 
-The goal is to add (unsafe) user-defined rewrite rules. This features allows
+The goal is to add (unsafe) user-defined rewrite rules. This feature allows
 users to add computation rules to axioms which can be useful for prototyping.
 It also allows for different kinds of computation rules with respect to what Coq
 currently permits: non-linearity, overlapping left-hand sides (*eg* one can write

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -184,7 +184,7 @@ Sub items:
 
 Resources:
 
-- Enrico Tassi, Gaetan Gilbert
+- Enrico Tassi, Gaëtan Gilbert
 - 1 month of work, 6 months timeframe
 
 ### Libraries and community

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -259,11 +259,31 @@ a specific case of tables with a unit index.
 - Gaëtan Gilbert, Pierre-Marie Pédrot, (Enrico Tassi for the SSR part)
 - long term
 
-#### General recursive notations
-
-The objective is to grant wish coq/coq#7959 (see there for details).
+#### Notations
 
 - Hugo Herbelin, Pierre Roux
+
+##### General recursive notations
+
+The objective is to grant wish [#7959](https://github.com/coq/coq/issues/7959)
+(see there for details).
+
+##### Parsing
+
+We plan to remove the recovery mechanism of the camlp5/coqpp parsing
+engine (see [#17876](https://github.com/coq/coq/pull/17876)). This
+will make the parser simpler and easier to understand and will enable
+to actually implement `no associativity`, which is currently just an
+alias for `left associativity`. This should also pave the way to lift
+the restriction that a same parsing level cannot be both left and
+right associative, avoiding conflicts between libraries. See
+[CEP 71](https://github.com/coq/ceps/pull/71) for more details.
+
+We will finally precise the design of a more liberal handling of
+associativity levels, based on arbitrary strings and ordering
+constraints (alike universe constraints) rather than the current 0 to
+100 integers. This should ease combination of various libraries by
+limiting the current conflicts on notations.
 
 ### Tools
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -242,23 +242,6 @@ and defining the corresponding grammar rules for the Ltac2 language.
 The objective is to grant wish [#7959](https://github.com/coq/coq/issues/7959)
 (see there for details).
 
-##### Parsing
-
-We plan to remove the recovery mechanism of the camlp5/coqpp parsing
-engine (see [#17876](https://github.com/coq/coq/pull/17876)). This
-will make the parser simpler and easier to understand and will enable
-to actually implement `no associativity`, which is currently just an
-alias for `left associativity`. This should also pave the way to lift
-the restriction that a same parsing level cannot be both left and
-right associative, avoiding conflicts between libraries. See
-[CEP 71](https://github.com/coq/ceps/pull/71) for more details.
-
-We will finally precise the design of a more liberal handling of
-associativity levels, based on arbitrary strings and ordering
-constraints (alike universe constraints) rather than the current 0 to
-100 integers. This should ease combination of various libraries by
-limiting the current conflicts on notations.
-
 ### Tools
 
 #### Proved extraction
@@ -400,6 +383,33 @@ and extend them after the fact. With this feature, mutable definitions are just
 a specific case of tables with a unit index.
 
 `coqdoc` needs to understand Ltac2 (link to definitions, skip bodies).
+
+#### Parsing
+
+We plan to remove the recovery mechanism of the camlp5/coqpp parsing
+engine (see [#17876](https://github.com/coq/coq/pull/17876)). This
+will make the parser simpler and easier to understand and will enable
+to actually implement `no associativity`, which is currently just an
+alias for `left associativity`. This should also pave the way to lift
+the restriction that a same parsing level cannot be both left and
+right associative, avoiding conflicts between libraries. See
+[CEP 71](https://github.com/coq/ceps/pull/71) for more details.
+
+A first step required in this direction is to enable declaring
+notations at the same level than previous notations with a common
+prefix, without knowing the said level. This will make it possible to
+modify levels of notations without breaking backward compatibility
+with their dependencies. Once this first step done, users will need
+wait to require the Coq version implementing it, then use it to
+finally enable changing levels of notations that currently use the
+recovery mechanism. Fixing the levels of those notations will
+eventually enable to remove the recovery mechanism.
+
+We will finally precise the design of a more liberal handling of
+associativity levels, based on arbitrary strings and ordering
+constraints (alike universe constraints) rather than the current 0 to
+100 integers. This should ease combination of various libraries by
+limiting the current conflicts on notations.
 
 #### Attaching comments to declarations
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -104,7 +104,9 @@ Rules :
 
 - An item cannot be part of the roadmap if it is not supported by at least
   two persons, including at least one Coq maintainer to review the changes.
-- No one should be committed to work on more than two items at the same time.
+- No one should commit to more work than they can realistically undertake
+  at the same time (which will be a different amount depending on whether
+  someone can work full time on Coq or not).
 
 Each Coq Call will start with a roundtable about progress on items of the
 roadmap.
@@ -171,11 +173,17 @@ This should allow having for instance a common inductive for SProp, Prop and Typ
 (instead of the current `sigT` `sig` `ex` and variations depending on if each of the 2 parameters and the output are SProp).
 
 Eventually may allow using a common implementation for Type and Prop setoid rewriting machinery 
-(Morphisms vs CMorphisms, RelationClasses vs CRelationsClasses).
+(`Morphisms` vs `CMorphisms`, `RelationClasses` vs `CRelationsClasses`).
 
 May also be useful when doing Observational Type Theory.
 
 #### Algebraic universes
+
+- Matthieu Sozeau, Pierre-Marie Pédrot. Joint work with Marc Bezem on the constraint
+ inference/checking algorithms.
+- CEP: todo
+- PR: https://github.com/coq/coq/pull/16022
+- 1 year
 
 The goal is to support arbitrary universes (e.g. max(u+k, l)) in any position,
 while generalizing the constraint resolution system to support more complex constraints
@@ -194,13 +202,13 @@ On the user side this mostly adds an enriched language to describe universes wit
 Small syntactic incompatibilities related to universe declarations (e.g `@{u v + | u <= v +}` change
 to `@{u v ?| u <= v + 2 ?}`.
 
-- Matthieu Sozeau, Pierre-Marie Pédrot. Joint work with Marc Bezem on the constraint
- inference/checking algorithms.
-- CEP: todo
-- PR: https://github.com/coq/coq/pull/16022
-- 1 year
-
 #### Rewrite rules
+
+- Working Coq fork: https://github.com/Yann-Leray/coq (examples in
+https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.v).
+- CEP: https://github.com/coq/ceps/pull/50
+- Yann Leray, Théo Winterhalter
+- 3 to 6 month
 
 The goal is to add (unsafe) user-defined rewrite rules. This feature allows
 users to add computation rules to axioms which can be useful for prototyping.
@@ -215,49 +223,15 @@ reduction machines (not `vm_compute` and `native_compute` for now, Coq
 should give a warning when those are used with rewrite rules on). Rewrite
 rules would propagate to any module that requires the module that defines them.
 
-- Working Coq fork: https://github.com/Yann-Leray/coq (examples in
-https://github.com/Yann-Leray/coq/blob/rewrite-rules/test-suite/success/rewrule.v).
-- CEP: https://github.com/coq/ceps/pull/50
-- Yann Leray, Théo Winterhalter
-- 3 to 6 month
-
-#### Guard condition
-
-- Guard condition able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR coq/coq#17950), a few weeks for discussions and reviewing
-- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR coq/coq#17986), a few weeks for discussions and reviewing
-- Expanded constructors of a branch in a `match` considered smaller for the guard condition (CEP #73), a few weeks depending on discussions
-- Refinement of the guard condition through `match` constructs (PR coq/coq#14359), a few weeks for discussions and reviewing
-
-#### Sections
-
-- Design of a way to refer to the generalized version of a constant/inductive from within the inside of a section (depends on the time needed to reach a consensus on the design)
-
-#### Primitive projections
-
-Debate on the design to be had between Hugo Herbelin and Pierre-Marie Pédrot.
-
 ### Surface language
 
-#### Ltac2
+#### Make SSReflect available in Ltac2
 
-The overarching goal is to get to the point where we can recommend new
-developments to only use Ltac2 (without having to load Ltac1). There are several
-fronts on which to make progress.
-
-One major point is to make available in Ltac2 all the basic tactics from Ltac1.
-The main missing part is currently the ssreflect framework. Exposing it in Ltac2
+The main missing tactics in Ltac2 are currently those of SSReflect. Exposing them in Ltac2
 implies writing a good chunk of boilerplate binding code for the Ltac2-OCaml FFI
 and defining the corresponding grammar rules for the Ltac2 language.
 
-Another important thing for extensibility is the table feature. One should be
-able to define global tables with several kind of indices through a vernacular
-and extend them after the fact. With this feature, mutable definitions are just
-a specific case of tables with a unit index.
-
-`coqdoc` needs to understand Ltac2 (link to definitions, skip bodies).
-
-- Gaëtan Gilbert, Pierre-Marie Pédrot, (Enrico Tassi for the SSR part)
-- long term
+- Enrico Tassi and Pierre-Marie Pédrot
 
 #### Notations
 
@@ -299,16 +273,12 @@ Other aspects that need re-examination because they are problematic already in t
 - Module dependency analysis
 - Hugo Herbelin + Yannick Forster
 
-#### Attaching comments to declarations
-
-- Hugo Herbelin + ??
-- time needed to converge on the design
-
-PR [#18193](https://github.com/coq/coq/pull/18193) implements a table for binding comments to declarations, but it lacks surface syntax.
-
 ### Cleanup
 
 #### Retiring the STM, step 1
+
+- Enrico Tassi, Gaëtan Gilbert
+- 1 month of work, 6 months timeframe
 
 The objective of the first step is to have coqc and coqtop not depend on the STM, while keeping coqidetop, coqc-vio and coqc-vos depend on it.
 Sub items:
@@ -317,14 +287,12 @@ Sub items:
 - `par:` implemented using [SEL](https://github.com/gares/sel) (already done in vscoqtop, to be ported to Coq). Currently `par:` does not use the STM, but uses its code to spawn workers, it depends on `-thread` etc.
 - make coqc-vio and coqc-vos legacy binaries using the stm library
 
-Resources:
-
-- Enrico Tassi, Gaëtan Gilbert
-- 1 month of work, 6 months timeframe
-
 ### Libraries and community
 
 #### Boost stdlib development
+
+- Cyril Cohen, Pierre Roux
+- 6 months to 1 year
 
 As part of the promotion effort around the Coq Platform, we would like to
 ensure that the stdlib does not enjoy special status and that Coq can be
@@ -360,16 +328,40 @@ CI,...) will be discussed in a [CEP](https://github.com/coq/ceps/) to
 ensure a reasonnable agreement is reached on those points before
 implementing any actual change.
 
-Resources:
-
-- Cyril Cohen, Pierre Roux
-- 6 months to 1 year
-
 ## Medium term roadmap
 
-TODO: clean up and restructure this part.
+This part should be considered as a sketch, so not everything in there
+is presented at the same level of detail yet.
 
 ### Kernel, theory
+
+#### Streamline the use of `SProp`
+
+Short-term work on sort polymorphism should make it easier to adapt
+all tactics and libraries so that `SProp` becomes actually usable.
+
+#### Guard condition
+
+There are several ways to make the guard condition evolve. Some
+usability issues today could be lifted if they are properly
+justified as not extending the theoretical set of functions that can
+be defined. The guard condition could be made more flexible by
+allowing to choose between a very safe mode, a normal / legacy mode,
+an experimental / extended mode, and the disabled mode that can
+already been set today.
+
+Here are some of the items that could possibly be worked on in the
+relative short-term depending on availability of reviewers and
+consensus on how to handle them:
+
+- Guard condition able to treat nested inductive types as mutual inductive types (recomputing the recursive structure dynamically), Hugo (PR coq/coq#17950), a few weeks for discussions and reviewing
+- Guard condition able to detect uniform parameters of inner fixpoints, Hugo (PR coq/coq#17986), a few weeks for discussions and reviewing
+- Expanded constructors of a branch in a `match` considered smaller for the guard condition (CEP #73), a few weeks depending on discussions
+- Refinement of the guard condition through `match` constructs (PR coq/coq#14359), a few weeks for discussions and reviewing
+
+#### Sections
+
+- Design of a way to refer to the generalized version of a constant/inductive from within the inside of a section (depends on the time needed to reach a consensus on the design)
 
 #### Observational type theory
 
@@ -377,7 +369,11 @@ TODO: clean up and restructure this part.
 
 - Hugo less convinced of the importance of global fixpoints vs modifying the fix/cofix rules of CIC so that they unfold for named fixpoints on the name rather than the body of the fix
 
-#### Primitive projections
+#### Streamline the use of primitive projections
+
+Some discussions still need to happen to create a precise plan on how to proceed.
+
+One item that is often discussed is the following:
 
 - Removal of compatibility layer
 
@@ -389,17 +385,34 @@ TODO: clean up and restructure this part.
 
 ### Surface language
 
-#### AST / interpretation
+#### Ltac2
 
-- Emilio?
+The overarching goal is to get to the point where we can recommend new
+developments to only use Ltac2 (without having to load Ltac1). There are several
+fronts on which to make progress.
+
+One major point is to make available in Ltac2 all the basic tactics from Ltac1.
+The main missing part is currently the ssreflect framework.
+
+Another important thing for extensibility is the table feature. One should be
+able to define global tables with several kind of indices through a vernacular
+and extend them after the fact. With this feature, mutable definitions are just
+a specific case of tables with a unit index.
+
+`coqdoc` needs to understand Ltac2 (link to definitions, skip bodies).
+
+#### Attaching comments to declarations
+
+- Hugo Herbelin + ??
+- time needed to converge on the design
+
+PR [#18193](https://github.com/coq/coq/pull/18193) implements a table for binding comments to declarations, but it lacks surface syntax.
+
+#### AST / interpretation
 
 #### Bi-dimensional notations
 
-- Emilio Jésus Gallego Arias, ??? (missing buddy)
-
 #### Nametab / libobject
-
-- Emilio Jésus Gallego Arias, ??? (missing buddy)
 
 #### Removing clenv
 
@@ -414,6 +427,12 @@ TODO: clean up and restructure this part.
 #### Reactive elaboration
 
 #### Functionalisation
+
+### Tools
+
+#### Remove CoqIDE
+
+See [068-coqide-split.md](068-coqide-split.md).
 
 ### Libraries and community
 

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -41,7 +41,7 @@ Producing a roadmap for the Coq project is important for several reasons:
 
 # Detailed design
 
-The Coq roadmap is declined at three levels: short, medium and long term.
+The Coq roadmap is defined at three levels: short, medium and long term.
 Each of these levels address different needs, but they should be checked
 for consistency with each other.
 
@@ -59,7 +59,7 @@ for consistency with each other.
 
 - The medium term roadmap is focused on areas where we see important progress
   being needed, which could take several years to complete, and for which we
-  do not always have the ressources needed. It is used to guide the renewal
+  do not always have the resources needed. It is used to guide the renewal
   of the short term roadmap, but also the search for new resources to make
   progress in these areas. The medium term roadmap should contains high level
   descriptions of the areas requiring progress, but can contain rough plans

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -6,12 +6,14 @@
 
 # Summary
 
-This CEP aims to establish a roadmap for the Coq project.
+This CEP aims to establish a short term roadmap for the Coq project (while
+also stating the need for a medium and long term roadmap as well).
+
 It highlights both:
 
-- what are considered as important axes to work on in the future,
-- what resources are available to work on these axes, and which axes we commit
-  to work on based on these resources.
+- what are considered as priorities for the short term future,
+- what priorities we commit to make progress on, based on the available
+  resources.
 
 Resources mean availability of persons to conduct the work. For technical axes,
 requiring changes in the Coq system, it includes availability of persons to
@@ -26,18 +28,58 @@ Producing a roadmap for the Coq project is important for several reasons:
   part of next releases, and what changes are more likely to be delayed
   because of lack of resources.
 
-- It helps Coq developers to focus on important axes, and to be more
-  efficient, by making sure that their work will be supported by other
-  developers, including reviewers.
+- It helps Coq developers to choose priorities together, and to work more
+  efficiently toward those by making sure that their work will be supported
+  by other developers, including reviewers.
 
-- It helps contributors to know in what areas their
-  contribution is likely to get
-  the most support from the Coq developers.
+- It helps contributors to know in what areas their contribution is likely
+  to receive the most support from the Coq developers.
 
-- It helps highlighting the axes where more resources are needed, and
-  where the Coq project should try to find more resources.
+- It helps highlighting other priorities where progress is not possible for
+  lack of resources are needed, and where the Coq project should aim to find
+  more resources.
 
 # Detailed design
+
+The Coq roadmap is declined at three levels: short, medium and long term.
+Each of these levels address different needs, but they should be checked
+for consistency with each other.
+
+- The short term roadmap is focused on priorities on which we are committed
+  to progress in the coming months and that are thus the most likely to
+  actually happen. We define a commitment from the Coq team as a commitment
+  of several (at least two) contributors, including at least one relevant
+  maintainer to review the work proposed by other contributors. The work
+  can include implementation work when the design is already clear, work on
+  the design from ideas that are well understood, or even exploratory work,
+  but we should only list the parts that are likely to converge in the
+  specified time-frame (i.e., if it is not clear if exploratory work will
+  lead to a solution that can be implemented, we should only commit on the
+  exploratory work).
+
+- The medium term roadmap is focused on areas where we see important progress
+  being needed, which could take several years to complete, and for which we
+  do not always have the ressources needed. It is used to guide the renewal
+  of the short term roadmap, but also the search for new resources to make
+  progress in these areas. The medium term roadmap should contains high level
+  descriptions of the areas requiring progress, but can contain rough plans
+  for how to proceed to make progress in these areas if the team already has a
+  vision about the steps needed.
+
+- The long term roadmap is focused on what our vision for the future of Coq is
+  and not necessarily how we are going to achieve it. It is used to provide
+  general ideas that we can check our medium and short term roadmaps against,
+  and to give users more clarity on what the future of Coq could look like. It
+  should include our vision of what kind of users Coq will target in the future.
+
+As creating a roadmap and keeping it updated and aligned with the actual goals
+of the team members requires a change of culture, we do not try to create all
+of these levels at the same time. In this CEP, we aim to produce a complete
+short term roadmap, and to start a sketch of the medium term roadmap. We will
+use our experience building the short term roadmap and keeping it up-to-date
+to improve the process and to start building more precisely the other levels.
+
+## Detailed design for the short term roadmap
 
 This roadmap is a consolidated view created by the Coq developers, based on
 their shared understanding of the priorities of the project and of the
@@ -73,7 +115,22 @@ progress being made.
 Théo Zimmermann will be the editorial coordinator of the roadmap, proposing
 to add and remove items, to reflect the evolution of the project.
 
-## Priorities and resources
+Once adopted through the CEP process, the roadmap will be kept up-to-date
+in a living document on the wiki (while the merged step will represent a
+point in time). From time to time, we will go back to using the CEP process
+to trigger a discussion with the community on the updated roadmap (and also
+to address more precisely the medium and long term levels of the roadmap).
+
+## Short term roadmap
+
+As this short term roadmap is focused on priorities for which we have
+committed resources, it should not be considered as an exhaustive list of
+the important aspects on which we hope Coq to progress in the future (more
+can be found in the medium term roadmap). Rather, it gives clarity of what
+should be the upcoming changes in the next releases. Yet, some changes may
+still find their way in the next releases without being listed first in
+this short term roadmap (although for significant changes, it would be
+better if they would).
 
 ### Change of Name: `Coq` -> `The Rocq Prover`
 
@@ -288,7 +345,9 @@ Resources:
 - Cyril Cohen, Pierre Roux
 - 6 months to 1 year
 
-## Other axes, without sufficient resources
+## Medium term roadmap
+
+TODO: clean up and restructure this part.
 
 ### Kernel, theory
 
@@ -365,13 +424,21 @@ As part of this effort we should do:
 
 # Drawbacks
 
-TODO
+Creating and updating a roadmap requires significant work in itself. Our
+view is that this work should be nonetheless useful by making the rest of
+the work around Coq more efficient.
 
 # Alternatives
 
-TODO
+We could either do nothing, or try to coordinate work on selected topics
+only, without creating a global overview and unified process. However,
+experience leads us to believe that this global overview and unified
+process is needed to create a shared understanding of the priorities of
+the project and to make significant progress toward them.
 
 # Unresolved questions
 
-- How to update the roadmap? Should this CEP be updated, or should we create new CEPs every few months to produce a new roadmap? Should we
-also maintain a wiki page with the roadmap, to cover the live progress?
+We leave many questions for future work, including the frequency of the
+CEPs needed to update the roadmap, how the regular discussion of the work
+on roadmap priorities will take place, and how to build the medium and
+long term roadmap.

--- a/text/069-coq-roadmap.md
+++ b/text/069-coq-roadmap.md
@@ -42,7 +42,7 @@ Producing a roadmap for the Coq project is important for several reasons:
 # Detailed design
 
 The Coq roadmap is defined at three levels: short, medium and long term.
-Each of these levels address different needs, but they should be checked
+Each of these levels addresses different needs, but they should be checked
 for consistency with each other.
 
 - The short term roadmap is focused on priorities on which we are committed
@@ -61,7 +61,7 @@ for consistency with each other.
   being needed, which could take several years to complete, and for which we
   do not always have the resources needed. It is used to guide the renewal
   of the short term roadmap, but also the search for new resources to make
-  progress in these areas. The medium term roadmap should contains high level
+  progress in these areas. The medium term roadmap should contain high level
   descriptions of the areas requiring progress, but can contain rough plans
   for how to proceed to make progress in these areas if the team already has a
   vision about the steps needed.
@@ -118,7 +118,7 @@ Théo Zimmermann will be the editorial coordinator of the roadmap, proposing
 to add and remove items, to reflect the evolution of the project.
 
 Once adopted through the CEP process, the roadmap will be kept up-to-date
-in a living document on the wiki (while the merged step will represent a
+in a living document on the wiki (while the merged CEP will represent a
 point in time). From time to time, we will go back to using the CEP process
 to trigger a discussion with the community on the updated roadmap (and also
 to address more precisely the medium and long term levels of the roadmap).


### PR DESCRIPTION
This is a draft PR for now because each item in the list should be completed with some more precise description of what they mean, what the planned outcomes are, etc. This work can only be done by those who proposed the items on the roadmap. Furthermore, we may need to add missing items or move items around, depending on actual availability of people to work on them.

Rendered: https://github.com/coq/ceps/blob/coq-roadmap/text/069-coq-roadmap.md