### PR TITLE
Enriched and unified syntax for reduction strategies

### DIFF
--- a/text/match-with-alias.md
+++ b/text/match-with-alias.md
@@ -71,4 +71,10 @@ For an inductive type `[... Ii : Δi -> si := {... Cij : Ωij -> Ii δij ...} ..
   ————————————————————————————————————————————————————————————————————————————————————————————————————
                 Γ ⊢ (match t as x in Ii y return P with ... Cij z as w => uij ... end) : P δ
 ```
-Then, for the guard condition, the new variable `w` is considered of the size of `t`.
+and new reduction rule is:
+```
+match (Cij u) as x in Ii y return P with ... Cij z as w => uij ... end
+ →
+uij[z,w:=u,Cij u]
+```
+while, for the guard condition, the new variable `w` is considered of the size of `t`.

--- a/text/match-with-alias.md
+++ b/text/match-with-alias.md
@@ -1,0 +1,74 @@
+- Title: Giving access in `match` to the expansion of the term being matched via an alias in order to support more fixpoints
+
+- Drivers: Hugo Herbelin
+
+----
+
+# Summary
+
+We propose to extend the context of each branch of `match` in the Calculus of Inductive Constructions with an alias referring to the constructor of the branch, so that more fixpoints are available in a "natural" way.
+
+# Motivation
+
+When writing fixpoints in inductive types with indices, there is a standard conflict between referring to the expansion of a variable being matched (so that its type corresponds to the type in the branch) or referring to the variable so that it is compatible with the guard when the fixpoint is later used in another fixpoint. A typical example (even without indices) is `Nat.sub`:
+```coq
+Fixpoint sub (n m : nat) {struct n} : nat :=
+  match n with
+  | S k, S l => sub k l
+  | _, _ => n
+  end
+```
+where it is important that `n` is not expanded.
+
+The proposal is to resolve this conflict by giving an explicit name to the expansion of the term being matched in a branch so that the guard condition knows that it is a decreasing argument and not a constructor disconnected from the term being matched. For instance, `Nat.sub` would be written:
+```coq
+fix sub (n m : nat) {struct n} : nat :=
+  match n, m with
+  | S k, S l => sub k l
+  | _ as n', _ => n'
+  end
+```
+
+In the case of an inductive type with no indices, this does not provide much, but the situation changes for type families. For instance, imagine we want to apply parametricity to `Nat.sub`. That would give:
+```coq
+Fixpoint is_sub (n : nat) (Pn : is_nat n) (m : nat) (Pm : is_nat m) : is_nat (Nat.sub n m) :=
+  match Pn in (is_nat n) return is_nat (Nat.sub n m) with
+  | is_O => is_O
+  | is_S x P_ =>
+      match
+        Pm in (is_nat m0)
+        return is_nat (match m0 with 0 => S x | S l => Nat.sub x l end)
+      with
+      | is_O => is_S x P_
+      | is_S l Pl => is_sub x P_ l Pl
+      end
+  end.
+```
+where, for typing, we have to expand `Pn` into a constructor in the right-hand side.
+
+With the proposed extension, we would write:
+```coq
+Fixpoint is_sub (n : nat) (Pn : is_nat n) (m : nat) (Pm : is_nat m) : is_nat (Nat.sub n m) :=
+  match Pn in (is_nat n) return is_nat (Nat.sub n m) with
+  | is_O as p => p
+  | is_S x P_ as p =>
+      match
+        Pm in (is_nat m0)
+        return is_nat (match m0 with 0 => S x | S l => Nat.sub x l end)
+      with
+      | is_O => p
+      | is_S l Pl => is_sub x P_ l Pl
+      end
+  end.
+```
+with `p` of the same type as the constructor but recognized as a subterm for the guard condition.
+
+# Details about the design
+
+For an inductive type `[... Ii : Δi -> si := {... Cij : Ωij -> Ii δij ...} ...]`, the proposed new typing rule is:
+```
+  Γ ⊢ t : Ii δ     Γ, y : Δi, x : Ii y ⊢ P : s    ... Γ, z : Ωij, w : Ii δij  ⊢ uij : P[y,x:=δij,Cij z] ...
+  ————————————————————————————————————————————————————————————————————————————————————————————————————
+                Γ ⊢ (match t as x in Ii y return P with ... Cij z as w => uij ... end) : P δ
+```
+Then, for the guard condition, the new variable `w` is considered of the size of `t`.

--- a/text/unified-reduction-strategies.md
+++ b/text/unified-reduction-strategies.md
@@ -1,0 +1,83 @@
+- Title: A unified view at reduction strategies with extended unfolding control 
+
+- Drivers: Hugo Herbelin
+
+----
+
+# Summary and motivation
+
+Each user-level, compilation-free, reduction strategy of Coq, `simpl`,
+`cbn`, `cbv`, `lazy`, come, in addition to a reduction order
+(call-by-name, call-by-value, call-by-need), with its own
+specificities, such as:
+
+- refolding (co)fixpoints (in `simpl` and `cbn`)
+- local specification of the kind of reduction to consider (`cbn`, `cbv`, `lazy`)
+- specification of a subterm to reduce (`simpl pattern`)
+- some static parameterization of the unfolding (argument flags `simpl never`, `simpl nonmeta`, `!`, `/`)
+
+The proposal is to go in the direction of one unified entry point to
+reduction strategies eventually supporting all combinations of the
+features currently provided only by one or the other entry point, thus
+gaining both in expressiveness and easiness to document. At the
+current time, the focus is however only on a unified syntax.
+
+Additionally, the proposal is intended to complement CEP coq/ceps#35
+(more fine-tuning of reduction) and CEP coq/ceps#84 (support for
+symbol sets, hereafter called unfol bases).
+
+# Detailed design
+
+We propose to elaborate a unified syntax for all four mentioned user-level reduction strategies on top of the following:
+
+```text
+red_expr   ::= red_name pattern_opt flags_opt
+red_name   ::= "cbv" | "cbn" | "lazy" | "simpl"
+pattern    ::= CONSTR
+flags      ::= "with" head_flag_opt flag_list unfold_bases
+head_flag  ::= "head"
+flag       ::= "beta" | "iota" | "zeta" | "match" | "fix" | "cofix" | "delta"
+unfold_bases       ::= "+" unfold_base signed_unfold_base_list | signed_unfold_base_list
+signed_unfold_base ::= unfold_base | "-" unfold_base
+unfold_base        ::= "[" QUALID_list "]" | IDENT constraint_opt | module "(" QUALID ")"
+constraint         ::= "(" op INT ")"
+op                 ::= "<" | ">" | "<=" | ">="
+```
+where:
+- `pattern` would work as it does currently in `simpl pattern`
+- the use of `with` is reminiscent of the `with hintbase` of `auto`, `autorewrite`, `autounfold`, `firstorder`, ...
+- `red_name with ...` can be abbreviated into `red_name ...` for consistency with the current syntax of `cbn`, `cbv`, `lazy`
+- `- unfold_base` would mean subtracting the given unfold_base to what has been computed so far
+- `unfold_base` in `signed_unfold_base` would mean adding to what has been computed so far
+- `+ unfold_base  signed_unfold_base_list` would mean starting from the current transparency state, adding `unfold_base`, and continuing with `signed_unfold_base_list`
+- `[ QUALID_list ]` would refers to a list of names controlling the reduction, be as it is now
+- `IDENT` would refer to an unfolding database (see CEP coq/ceps#84 about how to build such databases)
+- `module(QUALID)` would mean to include constants from module `QUALID`
+- one could add a variant of `module(QUALID)` for recursive inclusion
+- `constraint` would select a subset of the bases depending on the level of the hint
+- the list of names in `QUALID_list` could include constructors, e.g. `None` to reduce `match` only on constructor `None`
+- then, current flag `match` could be seen as an alias for declaring all constructors "unfoldable"
+- `iota` would remain an alias for `match` + `fix` + `cofix`
+- if both `delta` and bases are given, `delta` should be last in the list of flags
+
+Note: in a world where all fixpoint and cofixpoints are globally
+named, the trigerring of `iota` could thus be mostly controlled by
+giving or not the names of the relevant fixpoint, cofixpoints,
+projections, constructors.
+
+Note: we could also try to unify the syntax `[ QUALID_list ]` with the
+`using QUALID_list` clause of `auto` and `firstorder`.
+
+# Implementation issues
+
+The implementation work at this stage would be mostly at the parsing level or database management level:
+- a generic `pattern` combinator is already implemented (`contextually`), it is just a matter of encapsulating all reduction strategies with it
+- for database management, see CEP coq/ceps#84
+
+# Unresolved questions
+
+We would probably expect all reduction strategies to eventually do **refolding**? This refolding could be `simpl`-style (maximal refolding) or to just the surrounding name of the global (co)fixpoints.
+
+We would probably expect all reduction strategies to eventually support different **unfolding policies** (exposing `match`, supporting reduction of nested `match`/`fix`, supporting reduction of match-free constant which "simplify" the term in some sense).
+
+Would a **level**, like in `with_strategy level [...]` be useful?


### PR DESCRIPTION
In particular, the proposed syntax has:
- pattern selection for all reductions
- support for fine-tuning iota by enabling/disabling specific constructor names
- support for referring to unfolding databases as in coq/ceps#84

Rendered [here](https://github.com/herbelin/ceps/blob/unified-reduction-strategies/text/unified-reduction-strategies.md).

