### PR TITLE
Roadmap: attenuate the marketing tone slightly

### DIFF
--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -12,7 +12,7 @@ This roadmap outlines our vision for Rocq's future, focusing on four key pillars
 + **Open and Accessible**: The Rocq Prover provides user-friendly installation, comprehensive educational resources, and a thriving community to ensure everyone can benefit from its power.
 + **Trustworthy**: The Rocq Prover prioritizes self-verification and performance optimization, ensuring the highest level of trust and efficiency in your formal proofs.
 + **Maintainable**: We are committed to a clean and streamlined codebase, simplifying future development and reducing the burden on users.
-+ **Usable**: We will explore AI-powered features, streamlined domain-specific tools, and do our best to improve day-to-day usability for mathematicians, educators, and engineers alike.
++ **Usable**: We do our best to improve day-to-day usability for mathematicians, educators, and engineers alike. This includes exploring AI-powered features and streamlined domain-specific tools.
 
 *Join us in shaping the future of formal verification!*
 

--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -10,9 +10,9 @@ While Rocq leverages the rich heritage of Coq, it aims to keep evolving: deliver
 This roadmap outlines our vision for Rocq's future, focusing on four key pillars:
 
 + **Open and Accessible**: The Rocq Prover provides user-friendly installation, comprehensive educational resources, and a thriving community to ensure everyone can benefit from its power.
-+ **Trustworthy Proofs**: The Rocq Prover prioritizes self-verification and performance optimization, ensuring the highest level of trust and efficiency in your formal proofs.
-+ **Effortless Maintainability**: We are committed to a clean and streamlined codebase, simplifying future development and reducing the burden on users.
-+ **Enhanced Usability**: We will explore AI-powered features, streamlined domain-specific tools, and do our best to improve day-to-day usability for mathematicians, educators, and engineers alike.
++ **Trustworthy**: The Rocq Prover prioritizes self-verification and performance optimization, ensuring the highest level of trust and efficiency in your formal proofs.
++ **Maintainable**: We are committed to a clean and streamlined codebase, simplifying future development and reducing the burden on users.
++ **Usable**: We will explore AI-powered features, streamlined domain-specific tools, and do our best to improve day-to-day usability for mathematicians, educators, and engineers alike.
 
 *Join us in shaping the future of formal verification!*
 

--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -5,7 +5,7 @@ Rocq Long Term Roadmap
 
 The Rocq Development Team, building on 40 years of experience with Coq, is pleased to announce the Rocq Prover, the next-generation proof assistant. The Rocq Prover is designed to empower a diverse range of users, from mathematicians seeking formal rigor to software engineers building high-assurance systems.
 
-While Rocq leverages the rich heritage of Coq, it embraces a more agile development philosophy. This allows us to deliver impactful changes more frequently, accelerating innovation and user experience improvements.
+While Rocq leverages the rich heritage of Coq, it aims to keep evolving: deliver impactful changes, enable new research and improve the user experience.
 
 This roadmap outlines our vision for Rocq's future, focusing on four key pillars:
 


### PR DESCRIPTION
At the last [Coq call](https://github.com/coq/coq/wiki/Coq-Call-2024-10-01), @herbelin mentioned that the beginning of the Roadmap document feels a bit chatgpt-generated. The way I understand this comment is that the tone is trying to imitate marketing speech, which is uncommon in our community, and not necessarily something people are comfortable with -- clearly Hugo is not.

I think that it is good to be able to show, with a choice of tone: "we are serious about improving our communication, trying to become more popular". But hopefully it is possible to find a good middle ground that does not push people away by sounding like snake oil.

I'm sure that the present document is already a compromise reached by several people trying to find a good balance, but this discussion motivated me to try to tone the marketing down *just a little bit*.

This PR contains three independent commits, very small changes, only in the first few paragraphs:

- Rephrase the sentence that talks about "agile development" and "accelerating innovation", to say the same thing without those negatively-associated keywords.
- Rephrase the pillars to remove their fluffy adjectives.
- Rephrase the "Usable" description to not *start* with AI-powered tool. It's a bit unfair because I think that Coq is a place where applying AI makes sense, but personally I get bad vibes from projects that talk about AI first (or, worse, the blockchain), so I think that putting it as a second sentence could help.
