### PR TITLE
Propose an alternative for the second paragraph of the roadmap.

### DIFF
--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -5,7 +5,7 @@ Rocq Long Term Roadmap
 
 The Rocq Development Team, building on 40 years of experience with Coq, is pleased to announce the Rocq Prover, the next-generation proof assistant. The Rocq Prover is designed to empower a diverse range of users, from mathematicians seeking formal rigor to software engineers building high-assurance systems.
 
-While Rocq leverages the rich heritage of Coq, it embraces a more agile development philosophy. This allows us to deliver impactful changes more frequently, accelerating innovation and user experience improvements.
+Rocq builds upon the rich heritage and diverse ecosystem of Coq. We promote a development methodology which achieves the delicate balance of being mindful of compatibility and ecosystem maintainability, while sufficiently agile to deliver impactful changes frequently, boosting research and innovation, and continuously improving user experience.
 
 This roadmap outlines our vision for Rocq's future, focusing on four key pillars:
 

--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -5,7 +5,7 @@ Rocq Long Term Roadmap
 
 The Rocq Development Team, building on 40 years of experience with Coq, is pleased to announce the Rocq Prover, the next-generation proof assistant. The Rocq Prover is designed to empower a diverse range of users, from mathematicians seeking formal rigor to software engineers building high-assurance systems.
 
-Rocq builds upon the rich heritage and diverse ecosystem of Coq. We promote a development methodology which achieves the delicate balance of being mindful of compatibility and ecosystem maintainability, while sufficiently agile to deliver impactful changes frequently, boosting research and innovation, and continuously improving user experience.
+Rocq builds upon the rich heritage and diverse ecosystem of Coq. We promote a fast-paced development methodology to deliver impactful changes frequently, supporting academic and industrial research, and continuously improving user experience. At the same time, we are mindful of compatibility and ecosystem maintainability.
 
 This roadmap outlines our vision for Rocq's future, focusing on four key pillars:
 


### PR DESCRIPTION
This is a different attempt at improving the paragraph that remains debated in #93 (the commits changing the rest of the introduction having been merged already). Based on discussions in this pull request, it tries to make it clearer what we meant by "leverages the rich ecosystem" and a "more agile development philosophy".

We keep the word "agile", but we remove the word "more" (as suggested by Hugo) and the word "philosophy" (as suggested by Erik). We remove the word "leverages" (as suggested by Jim) in favor of "builds upon". We insist on our ecosystem and our care for compatibility and ecosystem maintainability (which was only implicit so far). We add "research" (as suggested by Gabriel), but we keep "innovation" next to it to insist that we want to see impact both in research and in industry.