### PR TITLE
Improve / adjust audience description D and E

### DIFF
--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -65,7 +65,7 @@ key pillars:
 
 - **Accessibilty:** The Rocq/Coq Platform delivers easy installation
   and package integration. We are also actively working on IDE
-  improvements for the various usages of the Rocq Prover.
+  improvements for the various usages of the Rocq Prover (all audiences).
 
 - **Documentation:** We strive to document best practices, tools, and
   packages, so as to enhance usability for newcomers and experienced

--- a/text/rocq-roadmap.md
+++ b/text/rocq-roadmap.md
@@ -54,11 +54,11 @@ key pillars:
   components (*e.g,.* [BedRock System](https://bedrocksystems.com/)
   and [Formal Vindication](https://formalv.com/)).
 
-- **(D) Researchers in Computer Science**: Academics explore novel
+- **(D) Interactive Theorem Proving Research**: Academics explore novel
   applications, usage and extensions of the Rocq Prover.
 
-- **(E) And beyond**: The Rocq Prover is used as a research instrument
-  in a wide range of domains including fundamental mathematics,
+- **(E) Research users**: The Rocq Prover is used as a research instrument
+  in a wide range of domains including programming language research, fundamental mathematics,
   computer algebra, robotics, cryptography, hardware design, etc.
 
 ### 1. Open and Accessible
@@ -110,7 +110,7 @@ key pillars:
 ### 4. Enhanced Usability
 
 - **Performance**: address performance limitations that impact
-  projects that are widely used in industry and academia (C, D).
+  projects that are widely used in industry and academia (C, D, E).
 
 - **AI-powered Features:** Leverage AI for improved suggestion
   mechanisms, proof search, information retrieval, error reporting,


### PR DESCRIPTION
"And beyond" was problematic because it didn't bring any consistency or vision. But in fact, it was specifically describing researchers in domains other than computer science. I propose to make this clearer by providing a title that is more specific than "And beyond", but also to draw the line at some other point between audiences D and E: instead of separating arbitrarily CS research and other research (making readers think that other research areas are less important), we draw the line between ITP research and research applying / using Rocq.